### PR TITLE
docs: update `pycaching` link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,4 +53,4 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 
 
 ## Other
-- [pycaching](https://pypi.org/project/pycaching/3.0.2/) - Python 3 interface for working with Geocaching.com website.
+- [pycaching](https://pypi.org/project/pycaching) - Python 3 interface for working with Geocaching.com website.


### PR DESCRIPTION
I'm not sure if this was done intentionally, but the link was set to 3.0.2 which is from 2014, this updates the link to use the latest version available.